### PR TITLE
Set since and (open) until build for the plugin.xml file

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,6 @@ repositories {
 intellij {
     version = "2020.1"
     setPlugins("IdeaVIM:0.60")
-    sameSinceUntilBuild = true
 }
 
 tasks.withType<PublishTask> {
@@ -29,5 +28,7 @@ tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml
     changeNotes("""
         Set maximum compatible version to `open` to remove restrictions on nightly IDE versions
       """)
+    setSinceBuild("201")
+    setUntilBuild("")
 }
 


### PR DESCRIPTION
Hi!
In continuation of https://github.com/Mishkun/ideavim-sneak/issues/1

Unfortunately, `sameSinceUntilBuild` is a bit different property. I've update build.gradle to get 201+ IJ compatibility. You can check the resulting `plugin.xml` using `patchPluginXml` gradle task (the file will be located under "build -> patchedPluginXmlFiles -> plugin.xml).
The number 201 is taken from this page: https://jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html