### PR TITLE
Feature/case

### DIFF
--- a/src/main/java/io/github/mishkun/ideavimsneak/IdeaVimSneakExtension.kt
+++ b/src/main/java/io/github/mishkun/ideavimsneak/IdeaVimSneakExtension.kt
@@ -34,6 +34,7 @@ import com.maddyhome.idea.vim.extension.VimExtensionHandler
 import com.maddyhome.idea.vim.extension.highlightedyank.DEFAULT_HIGHLIGHT_DURATION
 import com.maddyhome.idea.vim.helper.StringHelper
 import com.maddyhome.idea.vim.option.StrictMode
+import com.maddyhome.idea.vim.option.OptionsManager
 import java.awt.Font
 import java.awt.event.KeyEvent
 import java.util.concurrent.Executors
@@ -124,9 +125,18 @@ class IdeaVimSneakExtension : VimExtension {
     private enum class Direction(val offset: Int) {
         FORWARD(1) {
             override fun findBiChar(charSequence: CharSequence, position: Int, charone: Char, chartwo: Char): Int? {
+                var match: Boolean
+
                 for (i in (position + offset) until charSequence.length - 1) {
-                    if (charSequence[i] == charone &&
-                            charSequence[i + 1] == chartwo) {
+                    match = charSequence[i].equals(charone, ignoreCase = OptionsManager.ignorecase.isSet) &&
+                            charSequence[i + 1].equals(chartwo, ignoreCase = OptionsManager.ignorecase.isSet)
+                    if (OptionsManager.ignorecase.isSet && OptionsManager.smartcase.isSet) {
+                        if (charone.isUpperCase() || chartwo.isUpperCase()) {
+                            match = charSequence[i].equals(charone, ignoreCase = false) &&
+                                    charSequence[i + 1].equals(chartwo, ignoreCase = false)
+                        }
+                    }
+                    if (match) {
                         return i
                     }
                 }
@@ -135,9 +145,18 @@ class IdeaVimSneakExtension : VimExtension {
         },
         BACKWARD(-1) {
             override fun findBiChar(charSequence: CharSequence, position: Int, charone: Char, chartwo: Char): Int? {
+                var match: Boolean
+
                 for (i in (position + offset) downTo 0) {
-                    if (charSequence[i] == charone &&
-                            charSequence[i + 1] == chartwo) {
+                    match = charSequence[i].equals(charone, ignoreCase = OptionsManager.ignorecase.isSet) &&
+                            charSequence[i + 1].equals(chartwo, ignoreCase = OptionsManager.ignorecase.isSet)
+                    if (OptionsManager.ignorecase.isSet && OptionsManager.smartcase.isSet) {
+                        if (charone.isUpperCase() || chartwo.isUpperCase()) {
+                            match = charSequence[i].equals(charone, ignoreCase = false) &&
+                                    charSequence[i + 1].equals(chartwo, ignoreCase = false)
+                        }
+                    }
+                    if (match) {
                         return i
                     }
                 }
@@ -224,4 +243,5 @@ class IdeaVimSneakExtension : VimExtension {
             Font.PLAIN
         )
     }
+
 }

--- a/src/main/java/io/github/mishkun/ideavimsneak/IdeaVimSneakExtension.kt
+++ b/src/main/java/io/github/mishkun/ideavimsneak/IdeaVimSneakExtension.kt
@@ -125,18 +125,8 @@ class IdeaVimSneakExtension : VimExtension {
     private enum class Direction(val offset: Int) {
         FORWARD(1) {
             override fun findBiChar(charSequence: CharSequence, position: Int, charone: Char, chartwo: Char): Int? {
-                var match: Boolean
-
                 for (i in (position + offset) until charSequence.length - 1) {
-                    match = charSequence[i].equals(charone, ignoreCase = OptionsManager.ignorecase.isSet) &&
-                            charSequence[i + 1].equals(chartwo, ignoreCase = OptionsManager.ignorecase.isSet)
-                    if (OptionsManager.ignorecase.isSet && OptionsManager.smartcase.isSet) {
-                        if (charone.isUpperCase() || chartwo.isUpperCase()) {
-                            match = charSequence[i].equals(charone, ignoreCase = false) &&
-                                    charSequence[i + 1].equals(chartwo, ignoreCase = false)
-                        }
-                    }
-                    if (match) {
+                    if (matches(charSequence, i, charone, chartwo)) {
                         return i
                     }
                 }
@@ -145,18 +135,8 @@ class IdeaVimSneakExtension : VimExtension {
         },
         BACKWARD(-1) {
             override fun findBiChar(charSequence: CharSequence, position: Int, charone: Char, chartwo: Char): Int? {
-                var match: Boolean
-
                 for (i in (position + offset) downTo 0) {
-                    match = charSequence[i].equals(charone, ignoreCase = OptionsManager.ignorecase.isSet) &&
-                            charSequence[i + 1].equals(chartwo, ignoreCase = OptionsManager.ignorecase.isSet)
-                    if (OptionsManager.ignorecase.isSet && OptionsManager.smartcase.isSet) {
-                        if (charone.isUpperCase() || chartwo.isUpperCase()) {
-                            match = charSequence[i].equals(charone, ignoreCase = false) &&
-                                    charSequence[i + 1].equals(chartwo, ignoreCase = false)
-                        }
-                    }
-                    if (match) {
+                    if (matches(charSequence, i, charone, chartwo)) {
                         return i
                     }
                 }
@@ -165,6 +145,19 @@ class IdeaVimSneakExtension : VimExtension {
 
         };
         abstract fun findBiChar(charSequence: CharSequence, position: Int, charone: Char, chartwo: Char): Int?
+
+        fun matches(charSequence: CharSequence, charPosition: Int, charOne: Char, charTwo: Char): Boolean {
+            var match = charSequence[charPosition].equals(charOne, ignoreCase = OptionsManager.ignorecase.isSet) &&
+                    charSequence[charPosition + 1].equals(charTwo, ignoreCase = OptionsManager.ignorecase.isSet)
+
+            if (OptionsManager.ignorecase.isSet && OptionsManager.smartcase.isSet) {
+                if (charOne.isUpperCase() || charTwo.isUpperCase()) {
+                    match = charSequence[charPosition].equals(charOne, ignoreCase = false) &&
+                            charSequence[charPosition + 1].equals(charTwo, ignoreCase = false)
+                }
+            }
+            return match
+        }
     }
 
     private enum class RepeatDirection(val symb: String) {

--- a/src/main/java/io/github/mishkun/ideavimsneak/IdeaVimSneakExtension.kt
+++ b/src/main/java/io/github/mishkun/ideavimsneak/IdeaVimSneakExtension.kt
@@ -243,5 +243,4 @@ class IdeaVimSneakExtension : VimExtension {
             Font.PLAIN
         )
     }
-
 }

--- a/src/test/java/io/mishkun/github/ideavimsneak/IdeaVimSneakTest.kt
+++ b/src/test/java/io/mishkun/github/ideavimsneak/IdeaVimSneakTest.kt
@@ -18,6 +18,7 @@
 package io.mishkun.github.ideavimsneak
 
 import com.maddyhome.idea.vim.command.CommandState
+import junit.framework.TestCase
 
 class IdeaVimSneakTest : VimTestCase() {
     @Throws(Exception::class)
@@ -49,6 +50,30 @@ class IdeaVimSneakTest : VimTestCase() {
         val after = "som${c}e teXt"
 
         doTest("sxt", before, after, CommandState.Mode.COMMAND, CommandState.SubMode.NONE)
+    }
+
+    fun testSneakForwardIgnoreCase() {
+        val before = "som${c}e teXt"
+        val after = "some te${c}Xt"
+
+        enableExtensions("ignorecase")
+
+        doTest("sxt", before, after, CommandState.Mode.COMMAND, CommandState.SubMode.NONE)
+        doTest("sXt", before, after, CommandState.Mode.COMMAND, CommandState.SubMode.NONE)
+        doTest("sXT", before, after, CommandState.Mode.COMMAND, CommandState.SubMode.NONE)
+        doTest("sxT", before, after, CommandState.Mode.COMMAND, CommandState.SubMode.NONE)
+    }
+
+    fun testSneakForwardSmartIgnoreCase() {
+        val before = "som${c}e teXt"
+        val after = "some te${c}Xt"
+
+        enableExtensions("ignorecase", "smartcase")
+
+        doTest("sxt", before, after, CommandState.Mode.COMMAND, CommandState.SubMode.NONE)
+        doTest("sXt", before, after, CommandState.Mode.COMMAND, CommandState.SubMode.NONE)
+        doTest("sXT", before, before, CommandState.Mode.COMMAND, CommandState.SubMode.NONE)
+        doTest("sxT", before, before, CommandState.Mode.COMMAND, CommandState.SubMode.NONE)
     }
 
     fun testSneakForwardAndFindAgain() {


### PR DESCRIPTION
- Closes #17 

Unlike vim-sneak, which uses `g:sneak#use_ic_scs` to enable this behavior,
I'm just taking into account Ideavim settings directly for now:
```
set ignorecase
set smartcase
```
Like in vim, in order for `smartcase` to work, `ignorecase` has to be set.
If you'd prefer using an ideavim-sneak specific option, please let me know.

I should also mention that I've never used Kotlin before, so I'm not sure if this is idiomatic enough.
I'm open to any critics or suggestions.