### PR TITLE
Map keys in VISUAL mode not SELECT

### DIFF
--- a/src/main/java/io/github/mishkun/ideavimsneak/Utils.kt
+++ b/src/main/java/io/github/mishkun/ideavimsneak/Utils.kt
@@ -29,14 +29,14 @@ import com.maddyhome.idea.vim.helper.StringHelper
  */
 fun VimExtension.mapToFunctionAndProvideKeys(keys: String, handler: VimExtensionHandler) {
     VimExtensionFacade.putExtensionHandlerMapping(
-        MappingMode.NVO,
+        MappingMode.NXO,
         StringHelper.parseKeys(command(keys)),
         owner,
         handler,
         false
     )
     VimExtensionFacade.putKeyMapping(
-        MappingMode.NVO,
+        MappingMode.NXO,
         StringHelper.parseKeys(keys),
         owner,
         StringHelper.parseKeys(command(keys)),


### PR DESCRIPTION
The current mapping uses `NVO`, which is a combination of NORMAL, VISUAL, OP_PENDING and SELECT. That means trying to type `s` or `S` in SELECT mode (which is like INSERT with a selection) triggers sneak functionality. It should use `NXO`, which is just NORMAL, VISUAL and OP_PENDING. This might seem odd, but is standard Vim terminology - `vmap` maps in VISUAL and SELECT mode, `xmap` is only VISUAL and `smap` is SELECT.